### PR TITLE
Support running at paths with spaces/special char

### DIFF
--- a/src/claude-auto-commit.js
+++ b/src/claude-auto-commit.js
@@ -566,10 +566,21 @@ Configuration:
   return options;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Check if this script is being run directly
+import { fileURLToPath } from 'url';
+import { pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const scriptPath = process.argv[1];
+
+// Compare the resolved paths
+if (__filename === scriptPath || pathToFileURL(scriptPath).href === import.meta.url) {
   const options = parseArgs();
   const autoCommit = new ClaudeAutoCommit(options);
-  autoCommit.run();
+  autoCommit.run().catch(error => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
 }
 
 export default ClaudeAutoCommit;


### PR DESCRIPTION
So I experienced #1 too, couldn't get the script to run at all. Claude managed to find and fix the error:

**Description:**
  The claude-auto-commit script fails to execute when installed in directories containing
  spaces or special characters (like "Mobile Documents" or paths with `~`). This is due to the
   URL encoding mismatch in the entry point check.

  **Problem:**
  The comparison `import.meta.url === \`file://\${process.argv[1]}\`` fails because:
  - `import.meta.url` returns properly URL-encoded paths (spaces as %20, ~ as %7E)
  - `process.argv[1]` contains the raw filesystem path
  - Direct string concatenation doesn't handle URL encoding

  **Solution:**
  Use Node's `fileURLToPath` and `pathToFileURL` utilities to properly compare file paths
  regardless of special characters.